### PR TITLE
Fix CodeSandbox functionality.

### DIFF
--- a/CodeSandbox/index.js
+++ b/CodeSandbox/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render } from 'react-dom';
+import { ComparisonCheckbox, StoreProvider } from '../src/index.js';
+
+render(
+	<React.Fragment>
+		<StoreProvider>
+			<ComparisonCheckbox product="PRO-2403251" />
+		</StoreProvider>
+	</React.Fragment>,
+	document.querySelector('#root')
+);

--- a/README.md
+++ b/README.md
@@ -75,4 +75,3 @@ cd build
 yarn login
 yarn publish --tag beta
 ```
-

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@sur-la-table/slt-ui",
 	"version": "1.0.0",
 	"description": "Sur la table UI library",
-	"main": "./index.js",
+	"main": "./CodeSandbox/index.js",
 	"scripts": {
 		"build": "babel-node --config-file ./builder/config/babel.config.js ./builder/build.js",
 		"prettier": "npx prettier --config ./prettier.config.js --write \"{,!(.git|*build|*dist|node_modules)/**/}*.{css,js,json,jsx,less,md,sass,scss}\"",


### PR DESCRIPTION
Now you can drop our main URL into CodeSandbox and have an instantly hackable sandbox.

Only question is ... are we using the `main` property in our root `package.json` for anything? Because this PR has it pointing to `CodeSandbox/index.js` ... I didn't see an `index.js` in our root folder, so I didn't think we were.

Signed-off-by: Ryan P. C. McQuen <ryanpcmcquen@member.fsf.org>