### PR TITLE
Point CodeSandbox to `v1.0.0` until module limit changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ More details on the sandbox functionality can be found [here](sandbox/README.md)
 
 Conversely, you can also hack on components using CodeSandbox:
 
-[![Edit @sur-la-table/slt-ui](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/SurLaTable/slt-ui/tree/master/)
+[![Edit @sur-la-table/slt-ui](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/SurLaTable/slt-ui/tree/v1.0.0/)
 
 ## Building:
 

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -12,4 +12,5 @@ Use `sandbox/index.js` as your app entry point. That will use your local compone
 We are working on bringing hot module replacement to the sandbox.
 
 You can also hack on our components using CodeSandbox:
-[![Edit @sur-la-table/slt-ui](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/SurLaTable/slt-ui/tree/master/)
+
+[![Edit @sur-la-table/slt-ui](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/SurLaTable/slt-ui/tree/v1.0.0/)


### PR DESCRIPTION
CodeSandbox has a 200 module limit, which `v1.1.0` surpassed, so our sandbox there needs to point to the old release until that is raised:
https://github.com/CompuIves/codesandbox-client/issues/1007