### PR TITLE
Bugfix/remove react event listener

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -39,7 +39,6 @@
 		"react": "^16.2.0",
 		"react-async-component": "^1.0.2",
 		"react-dom": "^16.2.0",
-		"react-event-listener": "^0.6.0",
 		"react-habitat": "^1.0.1",
 		"react-habitat-redux": "^2.0.4",
 		"react-jss": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
 		"react": "^16.2.0",
 		"react-async-component": "^1.0.2",
 		"react-dom": "^16.2.0",
-		"react-event-listener": "^0.6.0",
 		"react-habitat": "^1.0.1",
 		"react-habitat-redux": "^2.0.4",
 		"react-hot-loader": "^4.3.3",


### PR DESCRIPTION
This is breaking our build, we should merge to develop and make a new release with this dep removed.