### PR TITLE
Test build with npm and yarn.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 sudo: false
 node_js:
-    - "10"
+	- '10'
 install:
-    - yarn install
+	- npm install
+	- yarn install
 script:
-    - yarn test
+	- yarn test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"docs": "babel-node --config-file ./builder/config/babel.config.js ./docs/serve.config.js --dev",
 		"prettier": "npx prettier-eslint --list-different --config ./prettier.config.js --eslint-config-path ./.eslintrc.json --write \"{,!(.git|*build|*dist|node_modules)/**/}*.{css,js,json,jsx,less,md,sass,scss}\"",
 		"sandbox": "babel-node --config-file ./builder/config/babel.config.js ./DEPRECATED_sandbox/serve.config.js --dev",
-		"test": "yarn build && npm build"
+		"test": "yarn build && npm run build"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"docs": "babel-node --config-file ./builder/config/babel.config.js ./docs/serve.config.js --dev",
 		"prettier": "npx prettier-eslint --list-different --config ./prettier.config.js --eslint-config-path ./.eslintrc.json --write \"{,!(.git|*build|*dist|node_modules)/**/}*.{css,js,json,jsx,less,md,sass,scss}\"",
 		"sandbox": "babel-node --config-file ./builder/config/babel.config.js ./DEPRECATED_sandbox/serve.config.js --dev",
-		"test": "yarn build"
+		"test": "yarn build && npm build"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
As we've seen, `yarn` can cover up some missing dependencies when installing and building. For this reason, we should have Travis run the build with `yarn` and `npm`.